### PR TITLE
Add newline after each entry

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ function pinoStackdriver (line) {
       case 50: value.severity = 'ERROR'; break
       case 60: value.severity = 'CRITICAL'; break
     }
-    line = stringifyJson(value)
+    line = stringifyJson(value) + '\n'
   }
   return line
 }

--- a/index.js
+++ b/index.js
@@ -30,9 +30,9 @@ function pinoStackdriver (line) {
       case 50: value.severity = 'ERROR'; break
       case 60: value.severity = 'CRITICAL'; break
     }
-    line = stringifyJson(value) + '\n'
+    line = stringifyJson(value)
   }
-  return line
+  return line + '\n'
 }
 
 process.stdin.pipe(split(pinoStackdriver)).pipe(process.stdout)


### PR DESCRIPTION
Looking at the console, I think it's possible the lack of a newline is causing parsing errors from fluentd which tails a special log file created by kubernetes. I bet if I hit the site a bunch some log lines will hit the console (filling up a buffer).